### PR TITLE
chore: harmonize JDK to 17 for CI and Gradle toolchain

### DIFF
--- a/android/gradle/gradle-daemon-jvm.properties
+++ b/android/gradle/gradle-daemon-jvm.properties
@@ -10,4 +10,4 @@ toolchainUrl.UNIX.X86_64=https\://api.foojay.io/disco/v3.0/ids/398ffe3949748bfb1
 toolchainUrl.WINDOWS.AARCH64=https\://api.foojay.io/disco/v3.0/ids/2ddfb13e430f2b3a94c9c937d8d2f67e/redirect
 toolchainUrl.WINDOWS.X86_64=https\://api.foojay.io/disco/v3.0/ids/056dc25d3b9d168ede8b94d3d2f99942/redirect
 toolchainVendor=JETBRAINS
-toolchainVersion=21
+toolchainVersion=17


### PR DESCRIPTION
Set Gradle toolchain to Java 17 to match existing CI workflows and avoid JDK mismatches during branch validations. This aligns ndroid/gradle/gradle-daemon-jvm.properties and CI configurations.